### PR TITLE
fix: update config detection to use opencode.jsonc and improve JSONC …

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,13 @@
     "": {
       "name": "opencode-plugin",
       "dependencies": {
+        "@opencode-ai/plugin": "^1.0.162",
+        "jsonc-parser": "^3.3.1",
         "supermemory": "^4.0.0",
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^1.0.191",
         "@types/bun": "latest",
-      },
-      "peerDependencies": {
-        "typescript": "^5.9.3",
+        "typescript": "^5.7.3",
       },
     },
   },
@@ -26,6 +25,8 @@
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "supermemory": ["supermemory@4.0.0", "", {}, "sha512-xMN05PQ8kTv8DuXa2qf8h/9LaRI7v1Kz3Tutt97JPq+PzhGabKLv5YVbSgqHiPX5yXcSUBVBNYPPbhAQMF6GYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": "^1.0.162",
+    "jsonc-parser": "^3.3.1",
     "supermemory": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
This PR addresses issues with configuration detection and parsing during the setup process. It ensures the installer correctly identifies current OpenCode configuration files and handles common JSONC (JSON with Comments) formatting without crashing.

## Changes
* **Updated Config Detection**: Added `opencode.jsonc` and `opencode.json` to the search candidates in `findOpencodeConfig`.
* **Priority Alignment**: Prioritized `opencode.*` filenames over 
previous `config.*` names to match current extension standards.
* **Modernized Defaults**: Updated `createNewConfig` to default to `opencode.jsonc` for new installations.
* **Robust JSONC Parsing**: Improved `addPluginToConfig` to handle comments and trailing commas more gracefully, preventing "Failed to parse" errors on standard JSONC files.
* **Improved Error Reporting**: Added specific error messaging to the parsing logic to provide better diagnostic feedback to users.

## Context
These changes resolve the naming mismatch and parsing failures recently noted by the community (ref: [@shuv1337](https://x.com/shuv1337/status/2005042343305773452?s=20) on X). Verified locally by testing against existing `opencode.json` configurations.

## Checklist
- [x] Tested locally with `bun src/cli.ts setup`
- [x] Verified plugin injection into existing `.json` and `.jsonc` files
- [x] Removed temporary debug logs
<img width="1442" height="931" alt="CleanShot 2025-12-27 at 23 08 34@2x" src="https://github.com/user-attachments/assets/9e3f2059-1091-412e-bd9a-5357a5c32151" />