### PR TITLE
fix(jsonc): add trailing comma support

### DIFF
--- a/src/services/jsonc.ts
+++ b/src/services/jsonc.ts
@@ -1,6 +1,7 @@
 /**
  * Strips comments from JSONC content while respecting string boundaries.
  * Handles // and /* comments, URLs in strings, and escaped quotes.
+ * Also removes trailing commas to support more relaxed JSONC format.
  */
 export function stripJsoncComments(content: string): string {
   let result = "";
@@ -79,5 +80,6 @@ export function stripJsoncComments(content: string): string {
     i++;
   }
 
-  return result;
+  // Remove trailing commas before } or ]
+  return result.replace(/,\s*([}\]])/g, "$1");
 }


### PR DESCRIPTION
jsonc files may or may not contain trailing comma. 

Please see: 
- https://jsonc.org/#appendix-a-trailing-commas-and-jsonc
- https://www.npmjs.com/package/jsonc-parser?activeTab=readme -> allowTrailingComma

In the previous version, having trailing commas cause supermemory plugin to silently fail to load configuration. This changeset aims to add support to have trailing commas in `supermemory.jsonc` file, by extending regex to remove trailing comma.