### PR TITLE
feat: add ability to select exact containerTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,34 +199,64 @@ Create `~/.config/opencode/supermemory.jsonc`:
 {
   // API key (can also use SUPERMEMORY_API_KEY env var)
   "apiKey": "sm_...",
-  
+
   // Min similarity for memory retrieval (0-1)
   "similarityThreshold": 0.6,
-  
+
   // Max memories injected per request
   "maxMemories": 5,
-  
+
   // Max project memories listed
   "maxProjectMemories": 10,
-  
+
   // Max profile facts injected
   "maxProfileItems": 5,
-  
+
   // Include user profile in context
   "injectProfile": true,
-  
-  // Prefix for container tags
+
+  // Prefix for container tags (used when userContainerTag/projectContainerTag not set)
   "containerTagPrefix": "opencode",
-  
+
+  // Optional: Set exact user container tag (overrides auto-generated tag)
+  "userContainerTag": "my-custom-user-tag",
+
+  // Optional: Set exact project container tag (overrides auto-generated tag)
+  "projectContainerTag": "my-project-tag",
+
   // Extra keyword patterns for memory detection (regex)
   "keywordPatterns": ["log\\s+this", "write\\s+down"],
-  
+
   // Context usage ratio that triggers compaction (0-1)
   "compactionThreshold": 0.80
 }
 ```
 
 All fields optional. Env var `SUPERMEMORY_API_KEY` takes precedence over config file.
+
+### Container Tag Selection
+
+By default, container tags are auto-generated using `containerTagPrefix` plus a hash:
+- User tag: `{prefix}_user_{hash(git_email)}`
+- Project tag: `{prefix}_project_{hash(directory)}`
+
+You can override this by specifying exact container tags:
+
+```jsonc
+{
+  // Use a specific container tag for user memories
+  "userContainerTag": "my-team-workspace",
+
+  // Use a specific container tag for project memories
+  "projectContainerTag": "my-awesome-project"
+}
+```
+
+This is useful when you want to:
+- Share memories across team members (same `userContainerTag`)
+- Sync memories between different machines for the same project
+- Organize memories using your own naming scheme
+- Integrate with existing Supermemory container tags from other tools
 
 ## Usage with Oh My OpenCode
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,8 @@ interface SupermemoryConfig {
   maxProfileItems?: number;
   injectProfile?: boolean;
   containerTagPrefix?: string;
+  userContainerTag?: string;
+  projectContainerTag?: string;
   filterPrompt?: string;
   keywordPatterns?: string[];
   compactionThreshold?: number;
@@ -42,7 +44,7 @@ const DEFAULT_KEYWORD_PATTERNS = [
   "always\\s+remember",
 ];
 
-const DEFAULTS: Required<Omit<SupermemoryConfig, "apiKey">> = {
+const DEFAULTS: Required<Omit<SupermemoryConfig, "apiKey" | "userContainerTag" | "projectContainerTag">> = {
   similarityThreshold: 0.6,
   maxMemories: 5,
   maxProjectMemories: 10,
@@ -104,6 +106,8 @@ export const CONFIG = {
   maxProfileItems: fileConfig.maxProfileItems ?? DEFAULTS.maxProfileItems,
   injectProfile: fileConfig.injectProfile ?? DEFAULTS.injectProfile,
   containerTagPrefix: fileConfig.containerTagPrefix ?? DEFAULTS.containerTagPrefix,
+  userContainerTag: fileConfig.userContainerTag,
+  projectContainerTag: fileConfig.projectContainerTag,
   filterPrompt: fileConfig.filterPrompt ?? DEFAULTS.filterPrompt,
   keywordPatterns: [
     ...DEFAULT_KEYWORD_PATTERNS,

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -16,6 +16,12 @@ export function getGitEmail(): string | null {
 }
 
 export function getUserTag(): string {
+  // If userContainerTag is explicitly set, use it
+  if (CONFIG.userContainerTag) {
+    return CONFIG.userContainerTag;
+  }
+
+  // Otherwise, auto-generate based on containerTagPrefix
   const email = getGitEmail();
   if (email) {
     return `${CONFIG.containerTagPrefix}_user_${sha256(email)}`;
@@ -25,6 +31,12 @@ export function getUserTag(): string {
 }
 
 export function getProjectTag(directory: string): string {
+  // If projectContainerTag is explicitly set, use it
+  if (CONFIG.projectContainerTag) {
+    return CONFIG.projectContainerTag;
+  }
+
+  // Otherwise, auto-generate based on containerTagPrefix
   return `${CONFIG.containerTagPrefix}_project_${sha256(directory)}`;
 }
 


### PR DESCRIPTION
Adds the ability for users to specify exact containerTag values via configuration, similar to claude-code and OpenClaw plugins.

## Changes

- Added `userContainerTag` config option to override auto-generated user tag
- Added `projectContainerTag` config option to override auto-generated project tag
- Updated documentation with examples and use cases
- Maintains full backward compatibility with existing `containerTagPrefix`

## Benefits

- Share memories across team members
- Sync memories between machines
- Custom naming schemes
- Integration with existing Supermemory container tags

Closes #22

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/supermemoryai/opencode-supermemory/tree/claude/issue-22-20260216-2342) | [View job run](https://github.com/supermemoryai/opencode-supermemory/actions/runs/22080803416