### PR TITLE
test: guard synthetic part id compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
 
       - run: bun run typecheck
 
+      - run: bun test
+
       - run: bun run build
 
       - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "opencode-supermemory": "./dist/cli.js"
   },
   "scripts": {
+    "test": "bun test",
     "build": "bun build ./src/index.ts --outdir ./dist --target node && bun build ./src/cli.ts --outfile ./dist/cli.js --target node && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit"

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { formatContextForPrompt } from "./services/context.js";
 import { getTags } from "./services/tags.js";
 import { stripPrivateContent, isFullyPrivate } from "./services/privacy.js";
 import { createCompactionHook, type CompactionContext } from "./services/compaction.js";
+import { createSyntheticPartId } from "./services/part-id.js";
 
 import { isConfigured, CONFIG } from "./config.js";
 import { log } from "./services/logger.js";
@@ -112,7 +113,7 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
         if (detectMemoryKeyword(userMessage)) {
           log("chat.message: memory keyword detected");
           const nudgePart: Part = {
-            id: `prt_supermemory-nudge-${Date.now()}`,
+            id: createSyntheticPartId("nudge"),
             sessionID: input.sessionID,
             messageID: output.message.id,
             type: "text",
@@ -157,7 +158,7 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
 
           if (memoryContext) {
             const contextPart: Part = {
-              id: `prt_supermemory-context-${Date.now()}`,
+              id: createSyntheticPartId("context"),
               sessionID: input.sessionID,
               messageID: output.message.id,
               type: "text",

--- a/src/services/part-id.test.ts
+++ b/src/services/part-id.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { createSyntheticPartId } from "./part-id.js";
+
+describe("createSyntheticPartId", () => {
+  test("generates prt-prefixed context ids compatible with current OpenCode schema", () => {
+    expect(createSyntheticPartId("context", 1234567890)).toBe("prt_supermemory-context-1234567890");
+  });
+
+  test("generates prt-prefixed nudge ids compatible with current OpenCode schema", () => {
+    expect(createSyntheticPartId("nudge", 1234567890)).toBe("prt_supermemory-nudge-1234567890");
+  });
+});

--- a/src/services/part-id.ts
+++ b/src/services/part-id.ts
@@ -1,0 +1,3 @@
+export function createSyntheticPartId(kind: "context" | "nudge", now = Date.now()): string {
+  return `prt_supermemory-${kind}-${now}`;
+}


### PR DESCRIPTION
## Summary
- extract synthetic Supermemory part ID creation into a small helper with regression tests
- add a `bun test` release gate so future publishes cannot skip this compatibility check
- keep the existing `prt_supermemory-*` behavior but make it explicitly verified in CI

## Why
OpenCode 1.2.25+ enforces `prt`-prefixed part IDs. The repository source already contains the prefix fix, but the published 2.0.5 package still reproduced runtime failures with synthetic IDs like `supermemory-context-*` in my environment. This PR adds test and release protection so the compatibility fix remains enforced and future publishes cannot regress silently.

## Verification
- `bun test`
- `bun run typecheck`
- `bun run build`
- local OpenCode 1.3.2 repro with patched installed plugin no longer emitted `Invalid string: must start with \"prt\"`