### PR TITLE
feat: Add entity context

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ The `supermemory` tool is available to the agent:
 
 **Types:** `project-config`, `architecture`, `error-solution`, `preference`, `learned-pattern`, `conversation`
 
+OpenCode sends entity context when saving memories so Supermemory can extract
+different facts for user profile memories versus project/codebase knowledge.
+
 ## Memory Scoping
 
 | Scope   | Tag                                    | Persists     |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-supermemory",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "OpenCode plugin that gives coding agents persistent memory using Supermemory",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { stripJsoncComments } from "./services/jsonc.js";
 import { loadCredentials } from "./services/auth.js";
 
 const CONFIG_DIR = join(homedir(), ".config", "opencode");
-export const PLUGIN_VERSION = "2.0.7";
+export const PLUGIN_VERSION = "2.0.8";
 const CONFIG_FILES = [
   join(CONFIG_DIR, "supermemory.jsonc"),
   join(CONFIG_DIR, "supermemory.json"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import { tool } from "@opencode-ai/plugin";
 import {
   PROJECT_ENTITY_CONTEXT,
   USER_ENTITY_CONTEXT,
-  supermemoryClient,
-} from "./services/client.js";
+} from "./services/entity-context.js";
+import { supermemoryClient } from "./services/client.js";
 import { formatContextForPrompt } from "./services/context.js";
 import { getTags } from "./services/tags.js";
 import { stripPrivateContent, isFullyPrivate } from "./services/privacy.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import type { Plugin, PluginInput } from "@opencode-ai/plugin";
 import type { Part } from "@opencode-ai/sdk";
 import { tool } from "@opencode-ai/plugin";
 
-import { supermemoryClient } from "./services/client.js";
+import {
+  PROJECT_ENTITY_CONTEXT,
+  USER_ENTITY_CONTEXT,
+  supermemoryClient,
+} from "./services/client.js";
 import { formatContextForPrompt } from "./services/context.js";
 import { getTags } from "./services/tags.js";
 import { stripPrivateContent, isFullyPrivate } from "./services/privacy.js";
@@ -312,11 +316,14 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
                 const scope = args.scope || "project";
                 const containerTag =
                   scope === "user" ? tags.user : tags.project;
+                const entityContext =
+                  scope === "user" ? USER_ENTITY_CONTEXT : PROJECT_ENTITY_CONTEXT;
 
                 const result = await supermemoryClient.addMemory(
                   sanitizedContent,
                   containerTag,
-                  { type: args.type }
+                  { type: args.type },
+                  { entityContext }
                 );
 
                 if (!result.success) {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -162,7 +162,7 @@ export function startAuthFlow(timeoutMs = AUTH_TIMEOUT): Promise<AuthResult> {
         hostname: `opencode - ${hostname()}`,
         os: `${platform()}-${arch()}`,
         cwd: process.cwd(),
-        cli_version: "2.0.6",
+        cli_version: "2.0.8",
       });
       const authUrl = `${AUTH_BASE_URL}?${params.toString()}`;
 

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -11,31 +11,6 @@ const TIMEOUT_MS = 30000;
 const MAX_CONVERSATION_CHARS = 100_000;
 const OPENCODE_SOURCE = "opencode";
 
-export const USER_ENTITY_CONTEXT = `Developer coding session transcript for a persistent user profile.
-
-EXTRACT:
-- User preferences: preferred languages, frameworks, libraries, editors, workflows, and communication style
-- Stable habits: testing style, code review expectations, formatting preferences, privacy preferences
-- Repeated personal decisions: tools the user consistently chooses or avoids
-- Long-lived learnings: concepts the user learned or wants remembered across projects
-
-SKIP:
-- One-off assistant suggestions the user did not accept
-- Low-level implementation details that only matter inside the current repository`;
-
-export const PROJECT_ENTITY_CONTEXT = `Project/codebase knowledge from OpenCode coding sessions.
-
-EXTRACT:
-- Architecture: repo structure, services, modules, data flow, and integration boundaries
-- Conventions: naming, component patterns, API patterns, testing practices, and style rules
-- Decisions: chosen approaches, tradeoffs, migrations, and rejected alternatives
-- Setup: commands, environment requirements, deployment notes, and debugging workflows
-- Implementation lessons: bugs fixed, root causes, and reusable project-specific context
-
-SKIP:
-- Verbatim assistant explanations unless they became an accepted project decision
-- Transient command output with no lasting project value`;
-
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
     promise,

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -20,7 +20,6 @@ EXTRACT:
 - Long-lived learnings: concepts the user learned or wants remembered across projects
 
 SKIP:
-- Project-specific architecture unless it reflects a durable user preference
 - One-off assistant suggestions the user did not accept
 - Low-level implementation details that only matter inside the current repository`;
 
@@ -34,7 +33,6 @@ EXTRACT:
 - Implementation lessons: bugs fixed, root causes, and reusable project-specific context
 
 SKIP:
-- Generic user preferences that are not specific to this project
 - Verbatim assistant explanations unless they became an accepted project decision
 - Transient command output with no lasting project value`;
 

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -9,6 +9,34 @@ import type {
 
 const TIMEOUT_MS = 30000;
 const MAX_CONVERSATION_CHARS = 100_000;
+const OPENCODE_SOURCE = "opencode";
+
+export const USER_ENTITY_CONTEXT = `Developer coding session transcript for a persistent user profile.
+
+EXTRACT:
+- User preferences: preferred languages, frameworks, libraries, editors, workflows, and communication style
+- Stable habits: testing style, code review expectations, formatting preferences, privacy preferences
+- Repeated personal decisions: tools the user consistently chooses or avoids
+- Long-lived learnings: concepts the user learned or wants remembered across projects
+
+SKIP:
+- Project-specific architecture unless it reflects a durable user preference
+- One-off assistant suggestions the user did not accept
+- Low-level implementation details that only matter inside the current repository`;
+
+export const PROJECT_ENTITY_CONTEXT = `Project/codebase knowledge from OpenCode coding sessions.
+
+EXTRACT:
+- Architecture: repo structure, services, modules, data flow, and integration boundaries
+- Conventions: naming, component patterns, API patterns, testing practices, and style rules
+- Decisions: chosen approaches, tradeoffs, migrations, and rejected alternatives
+- Setup: commands, environment requirements, deployment notes, and debugging workflows
+- Implementation lessons: bugs fixed, root causes, and reusable project-specific context
+
+SKIP:
+- Generic user preferences that are not specific to this project
+- Verbatim assistant explanations unless they became an accepted project decision
+- Transient command output with no lasting project value`;
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
@@ -57,7 +85,7 @@ export class SupermemoryClient {
       this.client = new Supermemory({
         apiKey: SUPERMEMORY_API_KEY,
         baseURL: getApiBaseUrl(),
-        defaultHeaders: { "x-sm-source": "opencode" },
+        defaultHeaders: { "x-sm-source": OPENCODE_SOURCE },
       });
       this.client.settings.update({
 	     	shouldLLMFilter: true,
@@ -111,25 +139,45 @@ export class SupermemoryClient {
   async addMemory(
     content: string,
     containerTag: string,
-    metadata?: { type?: MemoryType; tool?: string; [key: string]: unknown }
+    metadata?: { type?: MemoryType; tool?: string; [key: string]: unknown },
+    options?: { customId?: string; entityContext?: string }
   ) {
-    log("addMemory: start", { containerTag, contentLength: content.length });
+    log("addMemory: start", {
+      containerTag,
+      contentLength: content.length,
+      customId: options?.customId,
+      hasEntityContext: !!options?.entityContext,
+    });
     try {
       // Always stamp `sm_source` so mono's `document.source` column attributes
       // these writes to the OpenCode plugin. Caller-provided metadata wins on
       // conflicts.
       const mergedMetadata = {
-        sm_source: "opencode",
+        sm_source: OPENCODE_SOURCE,
         sm_capture_mode: metadata?.sm_capture_mode ?? "tool",
         ...(metadata ?? {}),
       } as unknown as Record<string, string | number | boolean | string[]>;
 
+      const payload: {
+        content: string;
+        containerTag: string;
+        metadata: Record<string, string | number | boolean | string[]>;
+        customId?: string;
+        entityContext?: string;
+      } = {
+        content,
+        containerTag,
+        metadata: mergedMetadata,
+      };
+      if (options?.customId) {
+        payload.customId = options.customId;
+      }
+      if (options?.entityContext) {
+        payload.entityContext = options.entityContext;
+      }
+
       const result = await withTimeout(
-        this.getClient().memories.add({
-          content,
-          containerTag,
-          metadata: mergedMetadata,
-        }),
+        this.getClient().memories.add(payload),
         TIMEOUT_MS
       );
       log("addMemory: success", { id: result.id });
@@ -183,7 +231,11 @@ export class SupermemoryClient {
     conversationId: string,
     messages: ConversationMessage[],
     containerTags: string[],
-    metadata?: Record<string, string | number | boolean>
+    metadata?: Record<string, string | number | boolean>,
+    options?: {
+      defaultEntityContext?: string;
+      entityContextByContainerTag?: Record<string, string>;
+    }
   ) {
     log("ingestConversation: start", {
       conversationId,
@@ -219,7 +271,11 @@ export class SupermemoryClient {
     let firstError: string | null = null;
 
     for (const tag of uniqueTags) {
-      const result = await this.addMemory(content, tag, ingestMetadata);
+      const entityContext =
+        options?.entityContextByContainerTag?.[tag] ?? options?.defaultEntityContext;
+      const result = await this.addMemory(content, tag, ingestMetadata, {
+        ...(entityContext ? { entityContext } : {}),
+      });
       if (result.success) {
         savedIds.push(result.id);
       } else if (!firstError) {

--- a/src/services/compaction.ts
+++ b/src/services/compaction.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { supermemoryClient } from "./client.js";
+import { PROJECT_ENTITY_CONTEXT, supermemoryClient } from "./client.js";
 import { log } from "./logger.js";
 import { CONFIG } from "../config.js";
 
@@ -301,7 +301,8 @@ export function createCompactionHook(
       const result = await supermemoryClient.addMemory(
         `[Session Summary]\n${summaryContent}`,
         tags.project,
-        { type: "conversation" }
+        { type: "conversation" },
+        { entityContext: PROJECT_ENTITY_CONTEXT }
       );
 
       if (result.success) {

--- a/src/services/compaction.ts
+++ b/src/services/compaction.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { PROJECT_ENTITY_CONTEXT, supermemoryClient } from "./client.js";
+import { PROJECT_ENTITY_CONTEXT } from "./entity-context.js";
+import { supermemoryClient } from "./client.js";
 import { log } from "./logger.js";
 import { CONFIG } from "../config.js";
 

--- a/src/services/entity-context.ts
+++ b/src/services/entity-context.ts
@@ -1,0 +1,24 @@
+export const USER_ENTITY_CONTEXT = `Developer coding session transcript for a persistent user profile.
+
+EXTRACT:
+- User preferences: preferred languages, frameworks, libraries, editors, workflows, and communication style
+- Stable habits: testing style, code review expectations, formatting preferences, privacy preferences
+- Repeated personal decisions: tools the user consistently chooses or avoids
+- Long-lived learnings: concepts the user learned or wants remembered across projects
+
+SKIP:
+- One-off assistant suggestions the user did not accept
+- Low-level implementation details that only matter inside the current repository`;
+
+export const PROJECT_ENTITY_CONTEXT = `Project/codebase knowledge from OpenCode coding sessions.
+
+EXTRACT:
+- Architecture: repo structure, services, modules, data flow, and integration boundaries
+- Conventions: naming, component patterns, API patterns, testing practices, and style rules
+- Decisions: chosen approaches, tradeoffs, migrations, and rejected alternatives
+- Setup: commands, environment requirements, deployment notes, and debugging workflows
+- Implementation lessons: bugs fixed, root causes, and reusable project-specific context
+
+SKIP:
+- Verbatim assistant explanations unless they became an accepted project decision
+- Transient command output with no lasting project value`;


### PR DESCRIPTION
## Summary

- Add user and project entity-context prompts for OpenCode memory writes.
- Forward `entityContext` through the OpenCode Supermemory client payload.
- Use user context for user-scope saves and project context for project saves and compaction summaries.
- Document the behavior in the README.