### PR TITLE
fix: move bundled deps to devDependencies to avoid 31 unneeded installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,12 +4,10 @@
   "workspaces": {
     "": {
       "name": "opencode-plugin",
-      "dependencies": {
-        "@opencode-ai/plugin": "^1.0.162",
-        "supermemory": "^4.0.0",
-      },
       "devDependencies": {
+        "@opencode-ai/plugin": "^1.0.162",
         "@types/bun": "latest",
+        "supermemory": "^4.0.0",
         "typescript": "^5.7.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-supermemory",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "OpenCode plugin that gives coding agents persistent memory using Supermemory",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,10 @@
     "type": "git",
     "url": "https://github.com/supermemoryai/opencode-supermemory"
   },
-  "dependencies": {
-    "@opencode-ai/plugin": "^1.0.162",
-    "supermemory": "^4.0.0"
-  },
   "devDependencies": {
+    "@opencode-ai/plugin": "^1.0.162",
     "@types/bun": "latest",
+    "supermemory": "^4.0.0",
     "typescript": "^5.7.3"
   },
   "opencode": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #62.

The published `package.json` declares `@opencode-ai/plugin` and `supermemory` as runtime `dependencies`, but `bun run build` already bundles them into `dist/index.js`. As a result, every consumer installing the plugin via `opencode plugin opencode-supermemory` pulls in ~31 packages that are never loaded at runtime.

## Root cause

`dist/index.js` is a self-contained bundle. I verified the built output imports **only Node built-ins** (`node:fs`, `node:os`, `node:path`, `node:crypto`, `node:child_process`, etc.) — there are no remaining bare imports of `@opencode-ai/plugin` or `supermemory`. Both are fully inlined by the bundler, so the runtime `dependencies` declaration is redundant and just forces redundant installs on consumers.

## Fix

Move `@opencode-ai/plugin` and `supermemory` from `dependencies` to `devDependencies`. They remain available for local development, type-checking, and the build (which inlines them), but are no longer installed on the consumer side.

The package continues to ship only `dist/` (per the `files` field), and the bundle is unchanged.

## Verification

- `bun run typecheck` — passes
- `bun run build` — passes; `index.js` still `0.53 MB`, self-contained (only Node built-ins imported)
- `bun test` — 6/6 pass
- `bun.lock` regenerated to reflect the dependency move

No source or bundled-output changes; this is purely a packaging metadata fix.

## Release

Bumps `version` to `2.0.11`. The `publish` workflow triggers on push to `main` when `package.json` changes and publishes to npm automatically once this merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://supermemory-ai.slack.com/archives/C09C397NUBE/p1785489541338739?thread_ts=1785489541.338739&cid=C09C397NUBE)

<div><a href="https://cursor.com/agents/bc-20cf4f88-6626-5026-89f5-2fd0f6b7cf74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20cf4f88-6626-5026-89f5-2fd0f6b7cf74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

