### PR TITLE
fix: forget search result memories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -524,9 +524,16 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
                 }
 
                 const scope = args.scope || "project";
+                const readTags =
+                  args.scope === "user"
+                    ? tags.personalReads
+                    : args.scope === "project"
+                      ? tags.projectReads
+                      : tags.allReads;
 
                 const result = await supermemoryClient.deleteMemory(
-                  args.memoryId
+                  args.memoryId,
+                  [tags.canonical, ...readTags],
                 );
 
                 if (!result.success) {
@@ -593,10 +600,15 @@ function formatSearchResults(
     query,
     scope,
     count: memoryResults.length,
-    results: memoryResults.slice(0, limit || 10).map((r) => ({
-      id: r.id,
-      content: r.memory || r.chunk,
-      similarity: Math.round((r.similarity ?? 0) * 100),
-    })),
+    results: memoryResults.slice(0, limit || 10).map((r) => {
+      const result = {
+        content: r.memory ?? r.chunk,
+        similarity: Math.round((r.similarity ?? 0) * 100),
+      };
+
+      return r.memory === undefined
+        ? { ...result, forgettable: false }
+        : { id: r.id, ...result, forgettable: true };
+    }),
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -525,9 +525,9 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
 
                 const scope = args.scope || "project";
                 const readTags =
-                  args.scope === "user"
+                  scope === "user"
                     ? tags.personalReads
-                    : args.scope === "project"
+                    : scope === "project"
                       ? tags.projectReads
                       : tags.allReads;
 

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -98,6 +98,15 @@ function isNotFoundError(error: unknown): boolean {
   );
 }
 
+function isAuthorizationError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error.status === 401 || error.status === 403)
+  );
+}
+
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let id: ReturnType<typeof setTimeout>;
   const timeout = new Promise<T>((_, reject) => {
@@ -389,49 +398,47 @@ export class SupermemoryClient {
 
   async deleteMemory(memoryId: string, containerTags: string[] = []) {
     log("deleteMemory: start", { memoryId });
+    const uniqueTags = [...new Set(containerTags.filter(Boolean))];
+    let retainedAuthorizationError: unknown;
+
+    for (const [index, containerTag] of uniqueTags.entries()) {
+      try {
+        await withTimeout(
+          this.getClient().memories.forget({ id: memoryId, containerTag }),
+          TIMEOUT_MS,
+        );
+        log("deleteMemory: forgotten", { memoryId });
+        return { success: true as const };
+      } catch (error) {
+        if (isNotFoundError(error)) continue;
+        if (index > 0 && isAuthorizationError(error)) {
+          retainedAuthorizationError ??= error;
+          continue;
+        }
+
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        log("deleteMemory: forget error", { memoryId, error: errorMessage });
+        return { success: false as const, error: errorMessage };
+      }
+    }
+
     try {
       await withTimeout(
         this.getClient().memories.delete(memoryId),
         TIMEOUT_MS,
       );
-      log("deleteMemory: success", { memoryId });
+      log("deleteMemory: deleted document", { memoryId });
       return { success: true as const };
     } catch (error) {
-      if (!isNotFoundError(error)) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        log("deleteMemory: error", { memoryId, error: errorMessage });
-        return { success: false as const, error: errorMessage };
-      }
-
-      const uniqueTags = [...new Set(containerTags.filter(Boolean))];
-      let lastNotFoundError: unknown = error;
-
-      for (const containerTag of uniqueTags) {
-        try {
-          await withTimeout(
-            this.getClient().memories.forget({ id: memoryId, containerTag }),
-            TIMEOUT_MS,
-          );
-          log("deleteMemory: forgotten", { memoryId });
-          return { success: true as const };
-        } catch (forgetError) {
-          if (!isNotFoundError(forgetError)) {
-            const errorMessage =
-              forgetError instanceof Error
-                ? forgetError.message
-                : String(forgetError);
-            log("deleteMemory: forget error", { memoryId, error: errorMessage });
-            return { success: false as const, error: errorMessage };
-          }
-          lastNotFoundError = forgetError;
-        }
-      }
-
+      const errorToReturn =
+        isNotFoundError(error) && retainedAuthorizationError !== undefined
+          ? retainedAuthorizationError
+          : error;
       const errorMessage =
-        lastNotFoundError instanceof Error
-          ? lastNotFoundError.message
-          : String(lastNotFoundError);
+        errorToReturn instanceof Error
+          ? errorToReturn.message
+          : String(errorToReturn);
       log("deleteMemory: error", { memoryId, error: errorMessage });
       return { success: false as const, error: errorMessage };
     }

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -89,6 +89,15 @@ function supportsScopedCanonicalTag(containerTag: string): boolean {
   return /^repo_.+__[0-9a-f]{16}$/i.test(containerTag);
 }
 
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    error.status === 404
+  );
+}
+
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let id: ReturnType<typeof setTimeout>;
   const timeout = new Promise<T>((_, reject) => {
@@ -378,7 +387,7 @@ export class SupermemoryClient {
     }
   }
 
-  async deleteMemory(memoryId: string) {
+  async deleteMemory(memoryId: string, containerTags: string[] = []) {
     log("deleteMemory: start", { memoryId });
     try {
       await withTimeout(
@@ -388,8 +397,41 @@ export class SupermemoryClient {
       log("deleteMemory: success", { memoryId });
       return { success: true as const };
     } catch (error) {
+      if (!isNotFoundError(error)) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        log("deleteMemory: error", { memoryId, error: errorMessage });
+        return { success: false as const, error: errorMessage };
+      }
+
+      const uniqueTags = [...new Set(containerTags.filter(Boolean))];
+      let lastNotFoundError: unknown = error;
+
+      for (const containerTag of uniqueTags) {
+        try {
+          await withTimeout(
+            this.getClient().memories.forget({ id: memoryId, containerTag }),
+            TIMEOUT_MS,
+          );
+          log("deleteMemory: forgotten", { memoryId });
+          return { success: true as const };
+        } catch (forgetError) {
+          if (!isNotFoundError(forgetError)) {
+            const errorMessage =
+              forgetError instanceof Error
+                ? forgetError.message
+                : String(forgetError);
+            log("deleteMemory: forget error", { memoryId, error: errorMessage });
+            return { success: false as const, error: errorMessage };
+          }
+          lastNotFoundError = forgetError;
+        }
+      }
+
       const errorMessage =
-        error instanceof Error ? error.message : String(error);
+        lastNotFoundError instanceof Error
+          ? lastNotFoundError.message
+          : String(lastNotFoundError);
       log("deleteMemory: error", { memoryId, error: errorMessage });
       return { success: false as const, error: errorMessage };
     }


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Fixes the `forget` tool for IDs returned by v4 memory search while preserving deletion for document IDs returned by list.

## Changes
- Use v4 memory forgetting as the primary operation across the canonical and scope-relevant legacy containers.
- Fall back to v3 document deletion only after the memory ID is absent from all relevant v4 containers.
- Preserve useful authorization/server errors without letting inaccessible legacy containers block valid document deletion.
- Mark hybrid chunk-only search results as non-forgettable and omit their unusable chunk IDs.

## Testing
- `PATH='/home/ubuntu/.bun/bin:'"$PATH" bun test` — passed, 6 tests and 0 failures.
- `PATH='/home/ubuntu/.bun/bin:'"$PATH" bun run typecheck` — passed.
- `PATH='/home/ubuntu/.bun/bin:'"$PATH" bun run build` — passed.
- `node dist/cli.js --help` — passed.
- Fake-transport harnesses verified v4-first routing, tag order/deduplication, all-404 v3 fallback, canonical and legacy authorization handling, server-error behavior, scoped container routing, and memory/chunk search formatting — passed.

Fixes #66.

<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/beeb0562-4b08-4095-94f0-bdec40809283)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
