### PR TITLE
Show Supermemory activity in OpenCode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,12 @@ import {
 } from "./services/context.js";
 import { createCaptureHook } from "./services/capture.js";
 import {
-  buildDirectRecallContext,
+  buildDirectRecallResult,
   buildRecallDirective,
   DIRECT_RECALL_TIMEOUT_MS,
   RecallSessionCache,
 } from "./services/recall.js";
+import { createMemoryActivityReporter } from "./services/activity.js";
 import {
   formatRecallHit,
   normalizeRecallResult,
@@ -25,7 +26,7 @@ import { createCompactionHook, type CompactionContext } from "./services/compact
 
 import { isConfigured, CONFIG, PLUGIN_VERSION } from "./config.js";
 import { log } from "./services/logger.js";
-import { checkNpmUpdate, formatUpdateNotice } from "./services/version-check.js";
+import { checkNpmUpdate } from "./services/version-check.js";
 import type { MemoryScope, MemoryType } from "./types/index.js";
 
 const CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
@@ -53,10 +54,6 @@ function detectMemoryKeyword(text: string): boolean {
   return MEMORY_KEYWORD_PATTERN.test(textWithoutCode);
 }
 
-function combineContextParts(parts: Array<string | null | undefined>): string {
-  return parts.map((part) => part?.trim()).filter(Boolean).join("\n\n");
-}
-
 function isSupermemoryRecallSearch(input: Permission): boolean {
   const type = String((input as { type?: unknown }).type ?? "");
   const title = String((input as { title?: unknown }).title ?? "").toLowerCase();
@@ -80,6 +77,7 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
   const tags = getTags(directory);
   const injectedSessions = new Set<string>();
   const recallSessions = new RecallSessionCache();
+  const activity = createMemoryActivityReporter(ctx.client);
   log("Plugin init", { directory, tags, configured: isConfigured() });
 
   if (!isConfigured()) {
@@ -120,7 +118,7 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
       })
     : null;
   const captureHook = isConfigured() && ctx.client
-    ? createCaptureHook(ctx, tags)
+    ? createCaptureHook(ctx, tags, { onSaved: () => activity.saved() })
     : null;
 
   return {
@@ -190,9 +188,9 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
               )
             : Promise.resolve(null);
 
-        const directRecall =
+        const directRecallPromise =
           CONFIG.recallMode === "direct"
-            ? buildDirectRecallContext({
+            ? buildDirectRecallResult({
                 prompt: userMessage,
                 sessionID: input.sessionID,
                 cache: recallSessions,
@@ -212,36 +210,46 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
                     )
                   : undefined,
               })
-            : Promise.resolve("");
+            : Promise.resolve({
+                context: "",
+                status: "skipped" as const,
+                count: 0,
+                tokens: 0,
+              });
 
         const firstMessage = isFirstMessage
-          ? Promise.all([
-              profileRequest,
-              checkNpmUpdate(
-                "opencode-supermemory",
-                PLUGIN_VERSION,
-                UPDATE_COMMAND,
-              ),
-            ]).then(([profileResult, updateInfo]) => {
+          ? profileRequest.then((profileResult) => {
               const profile = profileResult?.success ? profileResult : null;
-              const memoryContext = profile
+              return profile
                 ? formatContextForPrompt(
                     profile,
                     { results: [] },
                     { results: [] },
                   )
                 : "";
-              return combineContextParts([
-                memoryContext,
-                updateInfo ? formatUpdateNotice(updateInfo) : null,
-              ]);
             })
           : Promise.resolve("");
 
-        const [directRecallContext, firstMessageContext] = await Promise.all([
-          directRecall,
+        const updateCheck = isFirstMessage
+          ? checkNpmUpdate(
+              "opencode-supermemory",
+              PLUGIN_VERSION,
+              UPDATE_COMMAND,
+            )
+          : Promise.resolve(null);
+
+        const [directRecall, firstMessageContext, updateInfo] = await Promise.all([
+          directRecallPromise,
           firstMessage,
+          updateCheck,
         ]);
+
+        if (directRecall.status === "recalled") {
+          activity.recalled(directRecall.count, directRecall.tokens);
+        } else if (directRecall.status === "unavailable") {
+          activity.recallUnavailable();
+        }
+        if (updateInfo) activity.updateAvailable(updateInfo);
 
         if (firstMessageContext) {
           output.parts.unshift({
@@ -254,13 +262,13 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
           });
         }
 
-        if (directRecallContext) {
+        if (directRecall.context) {
           output.parts.push({
             id: `prt_supermemory-direct-recall-${Date.now()}`,
             sessionID: input.sessionID,
             messageID: output.message.id,
             type: "text",
-            text: directRecallContext,
+            text: directRecall.context,
             synthetic: true,
           });
         }
@@ -268,7 +276,7 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
         log("chat.message: context processed", {
           duration: Date.now() - start,
           firstMessageContextLength: firstMessageContext.length,
-          directRecallContextLength: directRecallContext.length,
+          directRecallContextLength: directRecall.context.length,
         });
 
       } catch (error) {
@@ -406,6 +414,8 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
                     error: result.error || "Failed to add memory",
                   });
                 }
+
+                activity.saved();
 
                 return JSON.stringify({
                   success: true,
@@ -595,6 +605,34 @@ export const SupermemoryPlugin: Plugin = async (ctx: PluginInput) => {
         }
       } catch (error) {
         log("permission.ask: ERROR", { error: String(error) });
+      }
+    },
+
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "supermemory") return;
+      const args = output.args as { mode?: unknown; query?: unknown };
+      if (args.mode === "search") {
+        activity.recalling(
+          typeof args.query === "string" ? args.query : undefined,
+        );
+      }
+    },
+
+    "tool.execute.after": async (input, output) => {
+      if (input.tool !== "supermemory") return;
+      try {
+        const result = JSON.parse(output.output) as {
+          success?: boolean;
+          count?: number;
+          results?: unknown[];
+        };
+        if (!result.success) return;
+        const count = result.count ?? result.results?.length;
+        if (typeof count === "number" && count > 0) {
+          activity.recalled(count, Math.round(output.output.length / 4));
+        }
+      } catch {
+        // Tool output remains authoritative when it is not structured JSON.
       }
     },
 

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,0 +1,76 @@
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import { log } from "./logger.js";
+import type { UpdateInfo } from "./version-check.js";
+
+type ToastVariant = "info" | "success" | "warning" | "error";
+
+interface ToastClient {
+  tui: {
+    showToast: PluginInput["client"]["tui"]["showToast"];
+  };
+}
+
+export interface MemoryActivityReporter {
+  recalling(query?: string): void;
+  recalled(count: number, tokens: number): void;
+  recallUnavailable(): void;
+  saved(): void;
+  updateAvailable(info: UpdateInfo): void;
+}
+
+export function createMemoryActivityReporter(
+  client: ToastClient,
+): MemoryActivityReporter {
+  const show = (
+    message: string,
+    variant: ToastVariant,
+    duration: number,
+  ) => {
+    void client.tui
+      .showToast({
+        body: {
+          title: "Supermemory",
+          message: `◪ supermemory · ${message}`,
+          variant,
+          duration,
+        },
+      })
+      .catch((error) => {
+        log("[activity] unable to show TUI notification", {
+          error: String(error),
+        });
+      });
+  };
+
+  return {
+    recalling(query) {
+      const suffix = query?.trim() ? `: ${query.trim().slice(0, 100)}` : "";
+      show(`recalling${suffix}`, "info", 2_000);
+    },
+    recalled(count, tokens) {
+      show(
+        `recalled ${count} ${count === 1 ? "memory" : "memories"} (${tokens} tok)`,
+        "success",
+        3_000,
+      );
+    },
+    recallUnavailable() {
+      show(
+        "recall unavailable; continuing without recalled context",
+        "warning",
+        3_000,
+      );
+    },
+    saved() {
+      show("saved this turn", "success", 2_000);
+    },
+    updateAvailable(info) {
+      show(
+        `update available: v${info.currentVersion} → v${info.latestVersion} · ${info.updateCommand}`,
+        "info",
+        8_000,
+      );
+    },
+  };
+}

--- a/src/services/capture.ts
+++ b/src/services/capture.ts
@@ -66,6 +66,7 @@ interface ConversationWriter {
 export interface CaptureOptions {
   captureEveryNTurns?: number;
   memoryClient?: ConversationWriter;
+  onSaved?: () => void;
 }
 
 function extractText(parts: Part[] | undefined): string {
@@ -281,6 +282,7 @@ export function createCaptureHook(
 
     if (result.success) {
       completedCaptureIds.add(captureId);
+      options?.onSaved?.();
       log("[capture] conversation batch saved", {
         sessionID,
         reason,

--- a/src/services/recall.test.ts
+++ b/src/services/recall.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildDirectRecallContext,
+  buildDirectRecallResult,
   MAX_RECALL_QUERY_CHARS,
   RecallSessionCache,
 } from "./recall.js";
@@ -114,5 +115,29 @@ describe("direct recall", () => {
     expect(context).toContain("This undisplayed profile fact may still be recalled");
     expect(context).toContain("Run typecheck before build");
     expect(context).toContain("◪");
+  });
+
+  test("reports visible recall counts and fail-open state", async () => {
+    const recalled = await buildDirectRecallResult({
+      prompt: "what did we decide about the build system",
+      sessionID: "session-visible",
+      cache: new RecallSessionCache(),
+      search: async () => ({
+        success: true,
+        results: [{ memory: "Use Bun", similarity: 0.9 }],
+      }),
+    });
+    expect(recalled.status).toBe("recalled");
+    expect(recalled.count).toBe(1);
+    expect(recalled.tokens).toBeGreaterThan(0);
+
+    const unavailable = await buildDirectRecallResult({
+      prompt: "what did we decide about the build system",
+      sessionID: "session-unavailable",
+      cache: new RecallSessionCache(),
+      search: async () => ({ success: false, error: "offline" }),
+    });
+    expect(unavailable.status).toBe("unavailable");
+    expect(unavailable.context).toBe("");
   });
 });

--- a/src/services/recall.ts
+++ b/src/services/recall.ts
@@ -123,13 +123,20 @@ function formatDirectRecallContext(hits: RecallHit[]): string {
   ].join("\n");
 }
 
-export async function buildDirectRecallContext(options: {
+export interface DirectRecallResult {
+  context: string;
+  status: "skipped" | "empty" | "recalled" | "unavailable";
+  count: number;
+  tokens: number;
+}
+
+export async function buildDirectRecallResult(options: {
   prompt: string;
   sessionID: string;
   cache: RecallSessionCache;
   search: (query: string) => Promise<SearchResponse>;
   suppressTexts?: Iterable<string> | Promise<Iterable<string>>;
-}): Promise<string> {
+}): Promise<DirectRecallResult> {
   try {
     const query = prepareRecallQuery(options.prompt);
     // Begin the search before waiting for first-turn profile suppression. Both
@@ -146,14 +153,34 @@ export async function buildDirectRecallContext(options: {
         await options.suppressTexts,
       );
     }
-    if (!query) return "";
+    if (!query) {
+      return { context: "", status: "skipped", count: 0, tokens: 0 };
+    }
 
     const response = await searchPromise;
-    if (!response?.success) return "";
+    if (!response?.success) {
+      return { context: "", status: "unavailable", count: 0, tokens: 0 };
+    }
     const hits = normalizeRecallResults(response.results ?? []);
     const freshHits = options.cache.takeFresh(options.sessionID, hits);
-    return freshHits.length > 0 ? formatDirectRecallContext(freshHits) : "";
+    if (freshHits.length === 0) {
+      return { context: "", status: "empty", count: 0, tokens: 0 };
+    }
+
+    const context = formatDirectRecallContext(freshHits);
+    return {
+      context,
+      status: "recalled",
+      count: freshHits.length,
+      tokens: Math.round(context.length / 4),
+    };
   } catch {
-    return "";
+    return { context: "", status: "unavailable", count: 0, tokens: 0 };
   }
+}
+
+export async function buildDirectRecallContext(
+  options: Parameters<typeof buildDirectRecallResult>[0],
+): Promise<string> {
+  return (await buildDirectRecallResult(options)).context;
 }


### PR DESCRIPTION
Shows native OpenCode notices when Supermemory recalls, saves, fails open, or has an update.\n\nKeeps update notices out of model context.